### PR TITLE
fixed potential crash

### DIFF
--- a/UICollectionViewExample/AFMasterViewController.m
+++ b/UICollectionViewExample/AFMasterViewController.m
@@ -143,10 +143,10 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
     
     switch(type) {
         case NSFetchedResultsChangeInsert:
-            change[@(type)] = @[@(sectionIndex)];
+            change[@(type)] = @(sectionIndex);
             break;
         case NSFetchedResultsChangeDelete:
-            change[@(type)] = @[@(sectionIndex)];
+            change[@(type)] = @(sectionIndex);
             break;
     }
     


### PR DESCRIPTION
Thanks for this really great example! :) :)
I personally like your style :)

When using it with sections it crashed for me in 

line 194: [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:[obj unsignedIntegerValue]]];

so i modified the following lines

obj was set as NSArray but used with NSValue

-> now i changed both lines (146 and 149) to following code:

change[@(type)] = @(sectionIndex); <-- is now NSValue
